### PR TITLE
Add react router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ env.sh
 .commando
 data/app/config.json
 release
+env.sh

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "axios": "^1.6.2",
+    "axios": "^1.6.7",
     "bootstrap": "^5.3.2",
     "copy-to-clipboard": "^3.3.3",
     "crypto-js": "^4.2.0",
@@ -21,20 +21,23 @@
     "node-sass": "^7.0.3",
     "qrcode.react": "^3.1.0",
     "react": "^18.2.0",
-    "react-bootstrap": "^2.9.1",
+    "react-bootstrap": "^2.10.1",
     "react-dom": "^18.2.0",
     "react-perfect-scrollbar": "^1.5.8",
+    "react-router-dom": "^6.22.1",
     "react-scripts": "^5.0.1"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^6.1.4",
-    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.5.1",
-    "@types/jest": "^29.5.10",
+    "@types/jest": "^29.5.12",
     "@types/node": "^20.9.4",
-    "@types/react": "^18.2.38",
-    "@types/react-dom": "^18.2.17",
-    "typescript": "^5.3.2"
+    "@types/react": "^18.2.61",
+    "@types/react-dom": "^18.2.19",
+    "axios-mock-adapter": "^1.22.0",
+    "ts-jest": "^29.1.2",
+    "typescript": "^4.9.4"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -49,6 +52,14 @@
       "last 1 chrome version",
       "last 1 firefox version",
       "last 1 safari version"
+    ]
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.[t|j]sx?$": "ts-jest"
+    },
+    "transformIgnorePatterns": [
+      "<rootDir>/node_modules/(?!axios)/"
     ]
   }
 }

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -37,7 +37,7 @@
     "@types/react-dom": "^18.2.19",
     "axios-mock-adapter": "^1.22.0",
     "ts-jest": "^29.1.2",
-    "typescript": "^4.9.4"
+    "typescript": "^5.4.2"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/apps/frontend/src/components/App/App.scss
+++ b/apps/frontend/src/components/App/App.scss
@@ -2,11 +2,6 @@
 @import '../../styles/constants';
 @import '../../styles/shared';
 
-.cards-container {
-  height: 67vh;
-  margin-bottom: 1.5rem;
-}
-
 .list-scroll-container {
   max-height: 48vh;
 }

--- a/apps/frontend/src/components/App/App.test.tsx
+++ b/apps/frontend/src/components/App/App.test.tsx
@@ -1,5 +1,18 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { act, render, screen } from '@testing-library/react';
+import App, { routeConfig } from './App';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { cleanup } from "@testing-library/react";
+
+jest.mock('../../services/logger.service', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+afterEach(cleanup);
 
 describe('App component ', () => {
   beforeEach(() => render(<App />));
@@ -7,4 +20,35 @@ describe('App component ', () => {
   it('should be in the document', () => {
     expect(screen.getByTestId('container')).not.toBeEmptyDOMElement()
   });
+});
+
+describe('App routing', () => {
+  const setUp = (async () => {
+    const router = createMemoryRouter(routeConfig, { initialEntries: ['/'] })
+
+    render(
+      <RouterProvider router={router} />
+    );
+
+    return { router }
+  });
+
+  it('redirects from / to /home', async () => {
+    let router = setUp();
+    expect((await router).router.state.location.pathname).toBe("/home");
+  });
+
+  it('going to bookkeeper hides the app view, preserves header', async () => {
+    let router = setUp();
+    expect(screen.getByTestId('header')).not.toBeEmptyDOMElement();
+    expect(screen.queryByTestId('cln-container')).toBeInTheDocument();
+    expect(screen.queryByTestId('bookkeeper-container')).not.toBeInTheDocument();
+    await act(async () => {
+      (await router).router.navigate("/bookkeeper");
+    })
+    expect((await router).router.state.location.pathname).toBe("/bookkeeper");
+    expect(screen.getByTestId('header')).not.toBeEmptyDOMElement();
+    expect(screen.queryByTestId('cln-container')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('bookkeeper-container')).toBeInTheDocument();
+  })
 });

--- a/apps/frontend/src/components/App/App.test.tsx
+++ b/apps/frontend/src/components/App/App.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen } from '@testing-library/react';
-import App, { routeConfig } from './App';
+import App, { rootRouteConfig } from './App';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 import { cleanup } from "@testing-library/react";
 
@@ -22,9 +22,9 @@ describe('App component ', () => {
   });
 });
 
-describe('App routing', () => {
+describe('Root routing', () => {
   const setUp = (async () => {
-    const router = createMemoryRouter(routeConfig, { initialEntries: ['/'] })
+    const router = createMemoryRouter(rootRouteConfig, { initialEntries: ['/'] })
 
     render(
       <RouterProvider router={router} />
@@ -38,7 +38,7 @@ describe('App routing', () => {
     expect((await router).router.state.location.pathname).toBe("/home");
   });
 
-  it('going to bookkeeper hides the app view, preserves header', async () => {
+  it('going to bookkeeper hides the cln view, preserves header', async () => {
     let router = setUp();
     expect(screen.getByTestId('header')).not.toBeEmptyDOMElement();
     expect(screen.queryByTestId('cln-container')).toBeInTheDocument();

--- a/apps/frontend/src/components/App/App.tsx
+++ b/apps/frontend/src/components/App/App.tsx
@@ -24,6 +24,68 @@ import CLNCard from '../cln/CLNCard/CLNCard';
 import ChannelsCard from '../cln/ChannelsCard/ChannelsCard';
 import logger from '../../services/logger.service';
 import { AuthResponse } from '../../types/app-config.type';
+import { Navigate, Outlet, RouterProvider, createBrowserRouter } from 'react-router-dom';
+
+export const routeConfig = [
+  {
+    path: "/", Component: Root,
+    children: [
+      { path: "/", Component: () => <Navigate to="/home" replace /> },
+      { path: "home", Component: CLN },
+      { path: "bookkeeper", Component: Bookkeeper },
+    ]
+  },
+];
+
+const router = createBrowserRouter(routeConfig);
+
+function Root() {
+  const appCtx = useContext(AppContext)
+  return (
+    <>
+      <Container className={appCtx.authStatus.isAuthenticated ? 'py-4' : 'py-4 blurred-container'} id='root-container' data-testid='container'>
+        <Header />
+        <Outlet />
+      </Container>
+      <ToastMessage />
+      <NodeInfo />
+      <ConnectWallet />
+      <LoginComponent />
+      <LogoutComponent />
+      <SetPasswordComponent />
+    </>
+  );
+}
+
+function CLN() {
+  return (
+    <div data-testid='cln-container'>
+      <Row>
+        <Col className='mx-1'>
+          <Overview />
+        </Col>
+      </Row>
+      <Row className='px-3'>
+        <Col xs={12} lg={4} className='cards-container'>
+          <BTCCard />
+        </Col>
+        <Col xs={12} lg={4} className='cards-container'>
+          <CLNCard />
+        </Col>
+        <Col xs={12} lg={4} className='cards-container'>
+          <ChannelsCard />
+        </Col>
+      </Row>
+    </div>
+  );
+}
+
+function Bookkeeper() {
+  return(
+    <div data-testid='bookkeeper-container'>
+    </div>
+  );
+}
 
 const App = () => {
   const appCtx = useContext(AppContext);
@@ -111,33 +173,7 @@ const App = () => {
   }
 
   return (
-    <>
-      <Container className={appCtx.authStatus.isAuthenticated ? 'py-4' : 'py-4 blurred-container'} id='root-container' data-testid='container'>
-        <Header />
-        <Row>
-          <Col className='mx-1'>
-            <Overview />
-          </Col>
-        </Row>
-        <Row className='px-3'>
-          <Col xs={12} lg={4} className='cards-container'>
-            <BTCCard />
-          </Col>
-          <Col xs={12} lg={4} className='cards-container'>
-            <CLNCard />
-          </Col>
-          <Col xs={12} lg={4} className='cards-container'>
-            <ChannelsCard />
-          </Col>
-        </Row>
-      </Container>
-      <ToastMessage />
-      <NodeInfo />
-      <ConnectWallet />
-      <LoginComponent />
-      <LogoutComponent />
-      <SetPasswordComponent />
-    </>
+    <RouterProvider router={router} />
   );
 };
 

--- a/apps/frontend/src/components/App/App.tsx
+++ b/apps/frontend/src/components/App/App.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 
 import './App.scss';
 import { useContext, useEffect } from 'react';
+import { Navigate, Outlet, RouterProvider, createBrowserRouter } from 'react-router-dom';
 import Container from 'react-bootstrap/Container';
-import Row from 'react-bootstrap/Row';
-import Col from 'react-bootstrap/Col';
-import Spinner from 'react-bootstrap/Spinner';
 
 import useHttp from '../../hooks/use-http';
 import useBreakpoint from '../../hooks/use-breakpoint';
@@ -13,81 +11,30 @@ import { AppContext } from '../../store/AppContext';
 import { ApplicationModes } from '../../utilities/constants';
 import ToastMessage from '../shared/ToastMessage/ToastMessage';
 import Header from '../ui/Header/Header';
-import Overview from '../cln/Overview/Overview';
 import NodeInfo from '../modals/NodeInfo/NodeInfo';
 import ConnectWallet from '../modals/ConnectWallet/ConnectWallet';
 import LoginComponent from '../modals/Login/Login';
 import LogoutComponent from '../modals/Logout/Logout';
 import SetPasswordComponent from '../modals/SetPassword/SetPassword';
-import BTCCard from '../cln/BTCCard/BTCCard';
-import CLNCard from '../cln/CLNCard/CLNCard';
-import ChannelsCard from '../cln/ChannelsCard/ChannelsCard';
 import logger from '../../services/logger.service';
 import { AuthResponse } from '../../types/app-config.type';
-import { Navigate, Outlet, RouterProvider, createBrowserRouter } from 'react-router-dom';
+import Bookkeeper from '../bookkeeper/BkprRoot/BkprRoot';
+import CLNHome from '../cln/CLNHome/CLNHome';
 
-export const routeConfig = [
+export const rootRouteConfig = [
   {
     path: "/", Component: Root,
     children: [
       { path: "/", Component: () => <Navigate to="/home" replace /> },
-      { path: "home", Component: CLN },
+      { path: "home", Component: CLNHome },
       { path: "bookkeeper", Component: Bookkeeper },
     ]
   },
 ];
 
-const router = createBrowserRouter(routeConfig);
+const rootRouter = createBrowserRouter(rootRouteConfig);
 
 function Root() {
-  const appCtx = useContext(AppContext)
-  return (
-    <>
-      <Container className={appCtx.authStatus.isAuthenticated ? 'py-4' : 'py-4 blurred-container'} id='root-container' data-testid='container'>
-        <Header />
-        <Outlet />
-      </Container>
-      <ToastMessage />
-      <NodeInfo />
-      <ConnectWallet />
-      <LoginComponent />
-      <LogoutComponent />
-      <SetPasswordComponent />
-    </>
-  );
-}
-
-function CLN() {
-  return (
-    <div data-testid='cln-container'>
-      <Row>
-        <Col className='mx-1'>
-          <Overview />
-        </Col>
-      </Row>
-      <Row className='px-3'>
-        <Col xs={12} lg={4} className='cards-container'>
-          <BTCCard />
-        </Col>
-        <Col xs={12} lg={4} className='cards-container'>
-          <CLNCard />
-        </Col>
-        <Col xs={12} lg={4} className='cards-container'>
-          <ChannelsCard />
-        </Col>
-      </Row>
-    </div>
-  );
-}
-
-function Bookkeeper() {
-  return(
-    <div data-testid='bookkeeper-container'>
-    </div>
-  );
-}
-
-const App = () => {
   const appCtx = useContext(AppContext);
   const currentScreenSize = useBreakpoint();
   const { setCSRFToken, getAppConfigurations, getAuthStatus, initiateDataLoading } = useHttp();
@@ -143,37 +90,25 @@ const App = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  if (appCtx.authStatus.isAuthenticated && appCtx.nodeInfo.isLoading) {
-    return (
-      <Container className='py-4' id='root-container' data-testid='container'>
-        <Header />
-        <Row className='mt-10'>
-          <Col xs={12} className='d-flex align-items-center justify-content-center'>
-            <Spinner animation='grow' variant='primary' />
-          </Col>
-          <Col xs={12} className='d-flex align-items-center justify-content-center'>
-            <div>Loading...</div>
-          </Col>
-        </Row>
-      </Container>
-    );
-  }
-
-  if (appCtx.nodeInfo.error) {
-    return (
-      <Container className='py-4' id='root-container' data-testid='container'>
-        <Header />
-        <Row className='message invalid mt-10'>
-          <Col xs={12} className='d-flex align-items-center justify-content-center'>
-            {appCtx.nodeInfo.error}
-          </Col>
-        </Row>
-      </Container>
-    );
-  }
-
   return (
-    <RouterProvider router={router} />
+    <>
+      <Container className={appCtx.authStatus.isAuthenticated ? 'py-4' : 'py-4 blurred-container'} id='root-container' data-testid='container'>
+        <Header />
+        <Outlet />
+      </Container>
+      <ToastMessage />
+      <NodeInfo />
+      <ConnectWallet />
+      <LoginComponent />
+      <LogoutComponent />
+      <SetPasswordComponent />
+    </>
+  );
+}
+
+const App = () => {
+  return (
+    <RouterProvider router={rootRouter} />
   );
 };
 

--- a/apps/frontend/src/components/bookkeeper/BkprRoot/BkprRoot.test.tsx
+++ b/apps/frontend/src/components/bookkeeper/BkprRoot/BkprRoot.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import Bookkeeper from './BkprRoot';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: jest.fn(),
+}));
+
+describe('Bookkeeper component ', () => {
+  beforeEach(() => render(<Bookkeeper />));
+
+  it('should be in the document', () => {
+    expect(screen.getByTestId('bookkeeper-container')).not.toBeEmptyDOMElement()
+  });
+});

--- a/apps/frontend/src/components/bookkeeper/BkprRoot/BkprRoot.tsx
+++ b/apps/frontend/src/components/bookkeeper/BkprRoot/BkprRoot.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import './BkprRoot.scss';
+import { ActionSVG } from '../../../svgs/Action';
+import Card from 'react-bootstrap/Card';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import { useNavigate } from 'react-router-dom';
+
+function Bookkeeper() {
+  const navigate = useNavigate();
+  return (
+    <div data-testid='bookkeeper-container'>
+      <Card className='d-flex align-items-stretch inner-box-shadow'>
+        <Card.Body className='text-dark d-flex align-items-stretch flex-column pt-4'>
+          <Card.Header className='p-0 d-flex align-items-start justify-content-between'>
+            <div className='fs-4 p-0 ps-3 fw-bold text-dark'>
+              Bookeeper
+            </div>
+          </Card.Header>
+          <Card.Body className='pb-0 px-1 d-flex flex-column align-items-start justify-content-between'>
+            <Row className='px-3 cards-container'>
+              <Col xs={12}>
+                Coming Soon!!!
+                <button tabIndex={1} type='submit' className='mt-5 btn-rounded bg-primary' onClick={() => navigate('/home')}>
+                  Home<ActionSVG className='ms-3' />
+                </button>
+              </Col>
+            </Row>
+          </Card.Body>
+          <Card.Footer className='d-flex justify-content-center'>
+          </Card.Footer>
+        </Card.Body>
+      </Card>
+    </div>
+  );
+}
+
+export default Bookkeeper;

--- a/apps/frontend/src/components/cln/CLNHome/CLNHome.scss
+++ b/apps/frontend/src/components/cln/CLNHome/CLNHome.scss
@@ -1,0 +1,8 @@
+@import '../../../styles/bootstrap-custom';
+@import '../../../styles/constants';
+@import '../../../styles/shared';
+
+.cards-container {
+  height: 67vh;
+  margin-bottom: 1.5rem;
+}

--- a/apps/frontend/src/components/cln/CLNHome/CLNHome.test.tsx
+++ b/apps/frontend/src/components/cln/CLNHome/CLNHome.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import CLNHome from './CLNHome';
+
+describe('CLNHome component ', () => {
+  beforeEach(() => render(<CLNHome />));
+
+  it('should be in the document', () => {
+    expect(screen.getByTestId('cln-container')).not.toBeEmptyDOMElement()
+  });
+});

--- a/apps/frontend/src/components/cln/CLNHome/CLNHome.tsx
+++ b/apps/frontend/src/components/cln/CLNHome/CLNHome.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import './CLNHome.scss';
+import { useContext } from 'react';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import Spinner from 'react-bootstrap/Spinner';
+
+import { AppContext } from '../../../store/AppContext';
+import Overview from '../Overview/Overview';
+import BTCCard from '../BTCCard/BTCCard';
+import CLNCard from '../CLNCard/CLNCard';
+import ChannelsCard from '../ChannelsCard/ChannelsCard';
+
+function CLNHome() {
+  const appCtx = useContext(AppContext);
+  if (appCtx.authStatus.isAuthenticated && appCtx.nodeInfo.isLoading) {
+    return (
+      <Row className='mt-10'>
+        <Col xs={12} className='d-flex align-items-center justify-content-center'>
+          <Spinner animation='grow' variant='primary' />
+        </Col>
+        <Col xs={12} className='d-flex align-items-center justify-content-center'>
+          <div>Loading...</div>
+        </Col>
+      </Row>
+    );
+  }
+
+  if (appCtx.nodeInfo.error) {
+    return (
+      <Row className='message invalid mt-10'>
+        <Col xs={12} className='d-flex align-items-center justify-content-center'>
+          {appCtx.nodeInfo.error}
+        </Col>
+      </Row>
+    );
+  }
+
+  return (
+    <div data-testid='cln-container'>
+      <Row>
+        <Col className='mx-1'>
+          <Overview />
+        </Col>
+      </Row>
+      <Row className='px-3'>
+        <Col xs={12} lg={4} className='cards-container'>
+          <BTCCard />
+        </Col>
+        <Col xs={12} lg={4} className='cards-container'>
+          <CLNCard />
+        </Col>
+        <Col xs={12} lg={4} className='cards-container'>
+          <ChannelsCard />
+        </Col>
+      </Row>
+    </div>
+  );
+}
+
+export default CLNHome;

--- a/apps/frontend/src/utilities/test-utilities.tsx
+++ b/apps/frontend/src/utilities/test-utilities.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import { AppContext, AppProvider } from '../store/AppContext';
+
+export const renderWithMockContext = (ui, { providerProps, ...renderOptions }) => {
+  return render(
+    <AppContext.Provider value={providerProps}>{ui}</AppContext.Provider>,
+    renderOptions
+  );
+};

--- a/env.sh
+++ b/env.sh
@@ -42,7 +42,7 @@ else
     export APP_CORE_LIGHTNING_DAEMON_GRPC_PORT=5002
     export APP_CORE_LIGHTNING_REST_PORT=3001
     export SINGLE_SIGN_ON=false
-    export CORE_LIGHTNING_PATH="/home/shahana/.lightning/l1-regtest"
+    export CORE_LIGHTNING_PATH="/home/.lightning/l1-regtest"
     export COMMANDO_CONFIG="$PWD/.commando"
     echo "Local Environment Variables Set"
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "@types/react-dom": "^18.2.19",
         "axios-mock-adapter": "^1.22.0",
         "ts-jest": "^29.1.2",
-        "typescript": "^4.9.4"
+        "typescript": "^5.4.2"
       }
     },
     "apps/frontend/node_modules/@jest/console": {
@@ -1254,16 +1254,16 @@
       }
     },
     "apps/frontend/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "apps/frontend/node_modules/v8-to-istanbul": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "@fortawesome/fontawesome-svg-core": "^6.4.2",
         "@fortawesome/free-solid-svg-icons": "^6.4.2",
         "@fortawesome/react-fontawesome": "^0.2.0",
-        "axios": "^1.6.2",
+        "axios": "^1.6.7",
         "bootstrap": "^5.3.2",
         "copy-to-clipboard": "^3.3.3",
         "crypto-js": "^4.2.0",
@@ -57,20 +57,23 @@
         "node-sass": "^7.0.3",
         "qrcode.react": "^3.1.0",
         "react": "^18.2.0",
-        "react-bootstrap": "^2.9.1",
+        "react-bootstrap": "^2.10.1",
         "react-dom": "^18.2.0",
         "react-perfect-scrollbar": "^1.5.8",
+        "react-router-dom": "^6.22.1",
         "react-scripts": "^5.0.1"
       },
       "devDependencies": {
-        "@testing-library/jest-dom": "^6.1.4",
-        "@testing-library/react": "^14.1.2",
+        "@testing-library/jest-dom": "^6.4.2",
+        "@testing-library/react": "^14.2.1",
         "@testing-library/user-event": "^14.5.1",
-        "@types/jest": "^29.5.10",
+        "@types/jest": "^29.5.12",
         "@types/node": "^20.9.4",
-        "@types/react": "^18.2.38",
-        "@types/react-dom": "^18.2.17",
-        "typescript": "^5.3.2"
+        "@types/react": "^18.2.61",
+        "@types/react-dom": "^18.2.19",
+        "axios-mock-adapter": "^1.22.0",
+        "ts-jest": "^29.1.2",
+        "typescript": "^4.9.4"
       }
     },
     "apps/frontend/node_modules/@jest/console": {
@@ -78,7 +81,6 @@
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
       "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -97,7 +99,6 @@
       "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
       "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -146,7 +147,6 @@
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
       "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/fake-timers": "^29.7.0",
@@ -163,7 +163,6 @@
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
       "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -182,7 +181,6 @@
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
       "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -199,7 +197,6 @@
       "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
       "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -244,8 +241,6 @@
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -258,7 +253,6 @@
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
       "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.18",
@@ -274,7 +268,6 @@
       "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
       "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -291,7 +284,6 @@
       "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
       "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -308,7 +300,6 @@
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
       "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -336,8 +327,6 @@
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -354,16 +343,13 @@
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "apps/frontend/node_modules/@sinonjs/commons": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
       "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
@@ -374,24 +360,23 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
     },
     "apps/frontend/node_modules/@testing-library/jest-dom": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.1.4.tgz",
-      "integrity": "sha512-wpoYrCYwSZ5/AxcrjLxJmCU6I5QAJXslEeSiMQqaWmP2Kzpd1LvF/qxmAIW2qposULGWq2gw30GgVNFLSc2Jnw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.2.tgz",
+      "integrity": "sha512-CzqH0AFymEMG48CpzXFriYYkOjk6ZGPCLMhW9e9jg3KMCn5OfJecF8GtGW7yGfR/IgCe3SX8BSwjdzI6BBbZLw==",
       "dev": true,
       "dependencies": {
-        "@adobe/css-tools": "^4.3.1",
+        "@adobe/css-tools": "^4.3.2",
         "@babel/runtime": "^7.9.2",
         "aria-query": "^5.0.0",
         "chalk": "^3.0.0",
         "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.5.6",
+        "dom-accessibility-api": "^0.6.3",
         "lodash": "^4.17.15",
         "redent": "^3.0.0"
       },
@@ -402,12 +387,16 @@
       },
       "peerDependencies": {
         "@jest/globals": ">= 28",
+        "@types/bun": "latest",
         "@types/jest": ">= 28",
         "jest": ">= 28",
         "vitest": ">= 0.32"
       },
       "peerDependenciesMeta": {
         "@jest/globals": {
+          "optional": true
+        },
+        "@types/bun": {
           "optional": true
         },
         "@types/jest": {
@@ -439,8 +428,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
       "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -450,7 +437,6 @@
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
@@ -473,7 +459,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
       "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -490,7 +475,6 @@
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
       "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.6.3",
@@ -508,7 +492,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -522,7 +505,6 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
@@ -538,7 +520,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
       "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -554,18 +535,22 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "apps/frontend/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true
     },
     "apps/frontend/node_modules/emittery": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
       "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -579,7 +564,6 @@
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
       "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/expect-utils": "^29.7.0",
@@ -597,7 +581,6 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
       "integrity": "sha512-EAMEJBsYuyyztxMxW3g7ugGPkrZsV57v0Hmv3mm1uQsmB+QnZuepg731CRaIgeUVSdmsTngOkSnauNF8p7FIhA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -615,7 +598,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
@@ -643,7 +625,6 @@
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
       "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "execa": "^5.0.0",
@@ -659,7 +640,6 @@
       "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
       "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -692,7 +672,6 @@
       "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
       "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
@@ -727,7 +706,6 @@
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
       "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -774,7 +752,6 @@
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
       "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -791,7 +768,6 @@
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
       "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
@@ -805,7 +781,6 @@
       "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
       "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -823,7 +798,6 @@
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
       "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -842,7 +816,6 @@
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -853,7 +826,6 @@
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
       "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -880,7 +852,6 @@
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
       "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "jest-get-type": "^29.6.3",
@@ -895,7 +866,6 @@
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
       "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -912,7 +882,6 @@
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -934,7 +903,6 @@
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
       "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -950,7 +918,6 @@
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -961,7 +928,6 @@
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
       "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -983,7 +949,6 @@
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
       "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "jest-regex-util": "^29.6.3",
@@ -998,7 +963,6 @@
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
       "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -1032,7 +996,6 @@
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
       "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -1067,7 +1030,6 @@
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
       "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -1100,8 +1062,6 @@
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
       "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -1119,7 +1079,6 @@
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
       "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -1138,7 +1097,6 @@
       "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
       "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -1159,7 +1117,6 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
       "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/node": "*",
@@ -1176,7 +1133,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -1193,7 +1149,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -1209,7 +1164,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -1223,7 +1177,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true,
-      "optional": true,
       "peer": true
     },
     "apps/frontend/node_modules/resolve.exports": {
@@ -1231,7 +1184,6 @@
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
       "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -1242,7 +1194,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1253,11 +1204,66 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "apps/frontend/node_modules/ts-jest": {
+      "version": "29.1.2",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.2.tgz",
+      "integrity": "sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==",
+      "dev": true,
+      "dependencies": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.3",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "^7.5.3",
+        "yargs-parser": "^21.0.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/types": "^29.0.0",
+        "babel-jest": "^29.0.0",
+        "jest": "^29.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
+      }
+    },
+    "apps/frontend/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "apps/frontend/node_modules/v8-to-istanbul": {
@@ -1265,7 +1271,6 @@
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
       "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
@@ -1281,7 +1286,6 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -1296,7 +1300,6 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -1316,8 +1319,6 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1331,9 +1332,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
-      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
+      "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
       "dev": true
     },
     "node_modules/@alloc/quick-lru": {
@@ -4097,7 +4098,6 @@
       "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
       "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "expect": "^29.7.0",
@@ -4133,7 +4133,6 @@
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
@@ -4147,7 +4146,6 @@
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
       "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -4175,7 +4173,6 @@
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -4194,7 +4191,6 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true,
-      "optional": true,
       "peer": true
     },
     "node_modules/@jest/expect/node_modules/@types/yargs": {
@@ -4202,7 +4198,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
       "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -4213,7 +4208,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -4227,7 +4221,6 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4238,7 +4231,6 @@
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
       "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/expect-utils": "^29.7.0",
@@ -4256,7 +4248,6 @@
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
       "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -4273,7 +4264,6 @@
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4284,7 +4274,6 @@
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
       "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -4311,7 +4300,6 @@
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
       "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -4328,7 +4316,6 @@
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -4350,7 +4337,6 @@
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4361,7 +4347,6 @@
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
       "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -4394,7 +4379,6 @@
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
       "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -4413,7 +4397,6 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
       "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/node": "*",
@@ -4430,7 +4413,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -4446,7 +4428,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true,
-      "optional": true,
       "peer": true
     },
     "node_modules/@jest/expect/node_modules/supports-color": {
@@ -4454,7 +4435,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -4471,7 +4451,6 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -4907,6 +4886,14 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.2.tgz",
+      "integrity": "sha512-+Rnav+CaoTE5QJc4Jcwh5toUpnVLKYbpU6Ys0zqbakqbaLQHeglLVHPfxOiQqdNmUy5C2lXz5dwC6tQNX2JW2Q==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@restart/hooks": {
       "version": "0.4.11",
       "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.11.tgz",
@@ -5312,9 +5299,9 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.1.2.tgz",
-      "integrity": "sha512-z4p7DVBTPjKM5qDZ0t5ZjzkpSNb+fZy1u6bzO7kk8oeGagpPCAtgh4cx1syrfp7a+QWkM021jGqjJaxJJnXAZg==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.2.1.tgz",
+      "integrity": "sha512-sGdjws32ai5TLerhvzThYFbpnF9XtL65Cjf+gB0Dhr29BGqK+mAeN7SURSdu+eqgET4ANcWoC7FQpkaiGvBr+A==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -5330,9 +5317,9 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "14.5.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.1.tgz",
-      "integrity": "sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==",
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
       "dev": true,
       "engines": {
         "node": ">=12",
@@ -5575,9 +5562,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.10",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.10.tgz",
-      "integrity": "sha512-tE4yxKEphEyxj9s4inideLHktW/x6DwesIwWZ9NN1FKf9zbJYsnhBoA9vrHA/IuIOKwPa5PcFBNV4lpMIOEzyQ==",
+      "version": "29.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -5800,9 +5787,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.4.tgz",
-      "integrity": "sha512-wmyg8HUhcn6ACjsn8oKYjkN/zUzQeNtMy44weTJSM6p4MMzEOuKbA3OjJ267uPCOW7Xex9dyrNTful8XTQYoDA==",
+      "version": "20.11.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.25.tgz",
+      "integrity": "sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -5851,9 +5838,9 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.38",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.38.tgz",
-      "integrity": "sha512-cBBXHzuPtQK6wNthuVMV6IjHAFkdl/FOPFIlkd81/Cd1+IqkHu/A+w4g43kaQQoYHik/ruaQBDL72HyCy1vuMw==",
+      "version": "18.2.64",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.64.tgz",
+      "integrity": "sha512-MlmPvHgjj2p3vZaxbQgFUQFvD8QiZwACfGqEdDSWou5yISWxDQ4/74nCAwsUiX7UFLKZz3BbVSPj+YxeoGGCfg==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5861,9 +5848,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.17.tgz",
-      "integrity": "sha512-rvrT/M7Df5eykWFxn6MYt5Pem/Dbyc1N8Y0S9Mrkw2WFCRiqUgw9P7ul2NpwsXCSM1DVdENzdG9J5SreqfAIWg==",
+      "version": "18.2.21",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.21.tgz",
+      "integrity": "sha512-gnvBA/21SA4xxqNXEwNiVcP0xSGHh/gi1VhWv9Bl46a0ItbTT5nFY+G9VSQpaG/8N/qdJpJ+vftQ4zflTtnjLw==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -6925,13 +6912,26 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-mock-adapter": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.22.0.tgz",
+      "integrity": "sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.5"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.17.0"
       }
     },
     "node_modules/axobject-query": {
@@ -7388,6 +7388,18 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -8149,7 +8161,6 @@
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
       "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -8172,7 +8183,6 @@
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
       "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -8191,7 +8201,6 @@
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
       "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/fake-timers": "^29.7.0",
@@ -8208,7 +8217,6 @@
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
       "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -8227,7 +8235,6 @@
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
       "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -8244,7 +8251,6 @@
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
@@ -8258,7 +8264,6 @@
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
       "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.18",
@@ -8274,7 +8279,6 @@
       "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
       "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -8291,7 +8295,6 @@
       "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
       "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -8308,7 +8311,6 @@
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
       "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -8336,7 +8338,6 @@
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -8355,7 +8356,6 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true,
-      "optional": true,
       "peer": true
     },
     "node_modules/create-jest/node_modules/@sinonjs/commons": {
@@ -8363,7 +8363,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
       "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
@@ -8374,7 +8373,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
@@ -8385,7 +8383,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
       "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -8396,7 +8393,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -8410,7 +8406,6 @@
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
@@ -8433,7 +8428,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
       "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -8450,7 +8444,6 @@
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
       "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.6.3",
@@ -8468,7 +8461,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -8482,7 +8474,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
       "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -8498,7 +8489,6 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -8509,7 +8499,6 @@
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
       "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -8523,7 +8512,6 @@
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
       "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/expect-utils": "^29.7.0",
@@ -8541,7 +8529,6 @@
       "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
       "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -8574,7 +8561,6 @@
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
       "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -8621,7 +8607,6 @@
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
       "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -8638,7 +8623,6 @@
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
       "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
@@ -8652,7 +8636,6 @@
       "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
       "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -8670,7 +8653,6 @@
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
       "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -8689,7 +8671,6 @@
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -8700,7 +8681,6 @@
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
       "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -8727,7 +8707,6 @@
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
       "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "jest-get-type": "^29.6.3",
@@ -8742,7 +8721,6 @@
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
       "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -8759,7 +8737,6 @@
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -8781,7 +8758,6 @@
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
       "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -8797,7 +8773,6 @@
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -8808,7 +8783,6 @@
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
       "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -8830,7 +8804,6 @@
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
       "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -8864,7 +8837,6 @@
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
       "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -8899,7 +8871,6 @@
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
       "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -8932,7 +8903,6 @@
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
       "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -8951,7 +8921,6 @@
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
       "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -8970,7 +8939,6 @@
       "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
       "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -8991,7 +8959,6 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
       "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/node": "*",
@@ -9008,7 +8975,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
@@ -9024,7 +8990,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true,
-      "optional": true,
       "peer": true
     },
     "node_modules/create-jest/node_modules/resolve.exports": {
@@ -9032,7 +8997,6 @@
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
       "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -9043,7 +9007,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -9054,7 +9017,6 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -9066,7 +9028,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -9083,7 +9044,6 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "dev": true,
-      "optional": true,
       "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -11412,9 +11372,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -12685,6 +12645,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-callable": {
@@ -17297,7 +17280,6 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
-      "optional": true,
       "peer": true
     },
     "node_modules/q": {
@@ -17455,9 +17437,9 @@
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/react-bootstrap": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.9.1.tgz",
-      "integrity": "sha512-ezgmh/ARCYp18LbZEqPp0ppvy+ytCmycDORqc8vXSKYV3cer4VH7OReV8uMOoKXmYzivJTxgzGHalGrHamryHA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.1.tgz",
+      "integrity": "sha512-J3OpRZIvCTQK+Tg/jOkRUvpYLHMdGeU9KqFUBQrV0d/Qr/3nsINpiOJyZMWnM5SJ3ctZdhPA6eCIKpEJR3Ellg==",
       "dependencies": {
         "@babel/runtime": "^7.22.5",
         "@restart/hooks": "^0.4.9",
@@ -17571,6 +17553,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.22.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.2.tgz",
+      "integrity": "sha512-YD3Dzprzpcq+tBMHBS822tCjnWD3iIZbTeSXMY9LPSG541EfoBGyZ3bS25KEnaZjLcmQpw2AVLkFyfgXY8uvcw==",
+      "dependencies": {
+        "@remix-run/router": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.22.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.2.tgz",
+      "integrity": "sha512-WgqxD2qySEIBPZ3w0sHH+PUAiamDeszls9tzqMPBDA1YYVucTBXLU7+gtRfcSnhe92A3glPnvSxK2dhNoAVOIQ==",
+      "dependencies": {
+        "@remix-run/router": "1.15.2",
+        "react-router": "6.22.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {


### PR DESCRIPTION
This commit adds react-router so that we can route to other pages, such as the upcoming Bookkeeper Dashboard page. It is set up so that the Header is shared among both the initial aka /home screen and the /bookkeeper screen. A redirect for '/' to '/home/' was added to support this shared header. Tests were written in App.test.tsx for this.

There is no discernible difference to a user with this change, other than if they manually navigate to /bookkeeper they will see a blank page. There is no button navigating to /bookkeeper and will not be until it is ready for production. This is so that regular pull request reviews can be done vs having to review a giant pull request with the new bookkeeper dashboard feature.

Test dependencies were updated and ts-jest + axios-mock-adapter were added so that components that import axios could be rendered in tests.